### PR TITLE
revert minSdkVersion to 21 again

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "de.wohlfrom.presenter"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 27
         versionCode 1
         versionName "0.9"


### PR DESCRIPTION
bluetooth seems not to work reliable on apis below 21, further adaption
is needed.