### PR TITLE
add configuration for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  # Some code cannot be tested, so we accept up to 90% coverage as green
+  range: "70...90"


### PR DESCRIPTION
since some of the code cannot be tested, we allow a test coverage
up to 90% as green