### PR TITLE
First unregister activity receiver before destroying ui

### DIFF
--- a/app/src/main/java/de/wohlfrom/presenter/connectors/bluetooth/DeviceSelector.java
+++ b/app/src/main/java/de/wohlfrom/presenter/connectors/bluetooth/DeviceSelector.java
@@ -175,15 +175,15 @@ public class DeviceSelector extends Fragment {
 
     @Override
     public void onDestroy() {
-        super.onDestroy();
+        // Unregister broadcast listeners
+        getActivity().unregisterReceiver(mReceiver);
 
         // Make sure we're not doing discovery anymore
         if (mBtAdapter != null) {
             mBtAdapter.cancelDiscovery();
         }
 
-        // Unregister broadcast listeners
-        getActivity().unregisterReceiver(mReceiver);
+        super.onDestroy();
     }
 
     /**


### PR DESCRIPTION
This avoids a null pointer exception on release builds